### PR TITLE
feat(heartbeat): unificar y estabilizar envío de heartbeats (Fix #6)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,6 +28,9 @@ services:
       - iot-network
     environment:
       - RUST_LOG=info
+      - EDGE_ID=edge-node-1
+      - COORDINATOR_URL=http://coordinator:3000/submit_report
+      - COORD_HB_URL=http://coordinator:3000/heartbeat
     volumes:
       - ./rust/edge:/app
     working_dir: /app

--- a/rust/edge/src/main.rs
+++ b/rust/edge/src/main.rs
@@ -167,6 +167,8 @@ async fn main() {
         let mut interval = time::interval(Duration::from_secs(3)); // Latido cada 3 segundos
         let hb_url = hb_state.coord_hb_url.clone();
 
+        println!("❤️ Heartbeat configurado hacia {}", hb_url);
+
         loop {
             interval.tick().await;
 

--- a/rust/edge/src/main.rs
+++ b/rust/edge/src/main.rs
@@ -14,6 +14,7 @@ struct AppState {
     readings: Arc<Mutex<Vec<SensorReading>>>,
     edge_id: String,
     coordinator_url: String,
+    coord_hb_url: String,
     sequence_counter: Arc<AtomicU64>,
 }
 
@@ -22,6 +23,7 @@ async fn main() {
     // Configuración con variables de entorno para Docker
     let edge_id = std::env::var("EDGE_ID").unwrap_or_else(|_| "edge-1".to_string());
     let coordinator_url = std::env::var("COORDINATOR_URL").unwrap_or_else(|_| "http://10.10.10.1:3000/submit_report".to_string());
+    let coord_hb_url = std::env::var("COORD_HB_URL").unwrap_or_else(|_| "http://10.10.10.1:3000/heartbeat".to_string());
     let port = std::env::var("PORT").unwrap_or_else(|_| "4000".to_string());
 
     // Inicializamos el estado vacío
@@ -29,6 +31,7 @@ async fn main() {
         readings: Arc::new(Mutex::new(Vec::new())),
         edge_id: edge_id.clone(),
         coordinator_url: coordinator_url.clone(),
+        coord_hb_url: coord_hb_url.clone(),
         sequence_counter: Arc::new(AtomicU64::new(0)),
     });
 
@@ -162,7 +165,7 @@ async fn main() {
     tokio::spawn(async move {
         let client = reqwest::Client::new();
         let mut interval = time::interval(Duration::from_secs(3)); // Latido cada 3 segundos
-        let hb_url = format!("{}/heartbeat", hb_state.coordinator_url.replace("/submit_report", ""));
+        let hb_url = hb_state.coord_hb_url.clone();
 
         loop {
             interval.tick().await;

--- a/rust/sensor/src/main.rs
+++ b/rust/sensor/src/main.rs
@@ -12,6 +12,7 @@ async fn main() {
     
     println!("🌡️ Iniciando {}...", sensor_id);
     println!("📡 Enviando ráfagas de datos a {}", edge_url);
+    println!("❤️ Heartbeat configurado hacia {}", coord_hb_url);
     
     let client = reqwest::Client::new();
     


### PR DESCRIPTION
### Resumen
Este Pull Request cierra formalmente el **Issue #6** añadiendo mejoras clave para la estabilidad y observabilidad del mecanismo de latidos (Heartbeats) que ya habíamos integrado previamente.

### Cambios realizados:
1. **Refactorización Segura del Edge:** Se eliminó la lógica frágil de `.replace()` para calcular la URL del coordinador. Ahora el nodo Edge recibe de manera explícita la variable `COORD_HB_URL` (al igual que el Sensor).
2. **Soporte en Docker Compose:** Se agregaron las inyecciones de variables `EDGE_ID`, `COORDINATOR_URL` y `COORD_HB_URL` para el servicio `edge` en el `docker-compose.yml`.
3. **Observabilidad:** Se agregaron prints en el Sensor y Edge para confirmar por consola la inicialización exitosa del hilo asíncrono de Heartbeats hacia la URL correcta.