### PR TITLE
feat(cluster): Remover heartbeats de sensores

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,9 +11,8 @@ services:
     environment:
       - RUST_LOG=info
       - SENSOR_ID=sensor-temp-1
-      # Inyección de dependencias estricta sin IPs hardcodeadas
+      # Los sensores solo envían datos a su Edge local
       - EDGE_URL=http://edge:4000/reading
-      - COORD_HB_URL=http://coordinator:3000/heartbeat
     depends_on:
       - edge
     cap_add:

--- a/rust/sensor/src/main.rs
+++ b/rust/sensor/src/main.rs
@@ -8,30 +8,12 @@ async fn main() {
     // Usamos variables de entorno para que Docker Compose pueda inyectar las IPs reales
     let sensor_id = std::env::var("SENSOR_ID").expect("FALTA VARIABLE: SENSOR_ID");
     let edge_url = std::env::var("EDGE_URL").expect("FALTA VARIABLE: EDGE_URL");
-    let coord_hb_url = std::env::var("COORD_HB_URL").expect("FALTA VARIABLE: COORD_HB_URL");
-    
+
     println!("🌡️ Iniciando {}...", sensor_id);
     println!("📡 Enviando ráfagas de datos a {}", edge_url);
-    println!("❤️ Heartbeat configurado hacia {}", coord_hb_url);
-    
+
     let client = reqwest::Client::new();
-    
-    // Hilo de Heartbeat para el Sensor
-    let sensor_id_hb = sensor_id.clone();
-    tokio::spawn(async move {
-        let client = reqwest::Client::new();
-        let mut interval = time::interval(Duration::from_secs(2));
-        loop {
-            interval.tick().await;
-            let hb = common::Heartbeat {
-                node_id: sensor_id_hb.clone(),
-                role: "sensor".to_string(),
-                timestamp_ms: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as u64,
-            };
-            let _ = client.post(&coord_hb_url).json(&hb).send().await;
-        }
-    });
-    
+
     // Configuramos el sensor para enviar 2 lecturas por segundo (cada 500ms)
     let mut interval = time::interval(Duration::from_millis(500));
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
En la arquitectura distribuida, solo los nodos Edge envían heartbeats al Coordinator. Los sensores son efímeros y locales, por lo que no necesitan heartbeat directo.

Cambios:
- Eliminar lógica de heartbeat de rust/sensor/src/main.rs
- Remover variable COORD_HB_URL del sensor en docker-compose.yml
- Actualizar comentarios para reflejar arquitectura correcta

Esto simplifica la arquitectura y reduce tráfico innecesario en la VPN. El Coordinator solo monitorea la salud de los Edges remotos.