### PR TITLE
feat(cluster): Preparar arquitectura Docker distribuida

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,159 @@
+# Configuración Docker del Pipeline IoT/Edge
+
+Este directorio contiene las configuraciones Docker para los diferentes modos de operación del sistema.
+
+## Archivos Disponibles
+
+### 1. `docker-compose.yml` (Legacy - Pruebas Locales)
+
+**Uso:** Desarrollo y pruebas en una sola máquina.
+
+```bash
+cd docker
+docker-compose up --build
+```
+
+**Características:**
+- Todos los servicios en una sola máquina
+- Comunicación por red Docker bridge (`iot-network`)
+- Sin requisitos de VPN
+- Ideal para desarrollo y debugging inicial
+
+---
+
+### 2. `docker-compose.coordinator.yml` (Cluster - Hub)
+
+**Uso:** Ejecutar en la máquina designada como **Hub** (Coordinator).
+
+**Requisitos:**
+- IP fija en la VPN: `10.10.10.1`
+- Puerto 3000 expuesto al exterior
+- WireGuard configurado y activo
+
+```bash
+# En la máquina Hub (10.10.10.1)
+cd docker
+docker-compose -f docker-compose.coordinator.yml up --build
+```
+
+**Servicios:**
+- `coordinator`: Recibe heartbeats y reportes de todos los edges vía VPN
+
+---
+
+### 3. `docker-compose.edge.yml` (Cluster - Nodos Edge)
+
+**Uso:** Ejecutar en **cada máquina** del equipo (excepto el Hub).
+
+**Requisitos:**
+- WireGuard conectado al Hub
+- Variable `COORDINATOR_IP` configurada
+- Variable `EDGE_ID` único por máquina
+
+```bash
+# En cada máquina edge (ej: 10.10.10.2, 10.10.10.3, etc.)
+export COORDINATOR_IP=10.10.10.1
+export EDGE_ID=edge-node-2  # Único por máquina
+
+cd docker
+docker-compose -f docker-compose.edge.yml up --build
+```
+
+**Servicios:**
+- `edge`: Procesa datos y envía al coordinator vía VPN
+- `sensor-1`, `sensor-2`: Generan datos (comunicación local con edge)
+
+---
+
+## Arquitectura del Cluster
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         VPN 10.10.10.0/24                       │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌──────────────┐                          ┌──────────────┐   │
+│  │   Hub        │◄─────────────────────────│  Máquina 2   │   │
+│  │  10.10.10.1  │      Heartbeats          │  10.10.10.2  │   │
+│  │              │◄─────────────────────────│   [Edge]     │   │
+│  │ [Coordinator]│      Edge Reports       │   /\         │   │
+│  │      │       │                          │   /  \       │   │
+│  │      │       │                          │[S1]  [S2]     │   │
+│  └──────┼───────┘                          └──────────────┘   │
+│         │                                                     │
+│         │                          ┌──────────────┐            │
+│         │                          │  Máquina 3   │            │
+│         └─────────────────────────►│  10.10.10.3  │            │
+│            Heartbeats/Reports      │   [Edge]     │            │
+│                                    │   /\         │            │
+│                                    │   /  \       │            │
+│                                    │[S1]  [S2]     │            │
+│                                    └──────────────┘            │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Guía Rápida de Despliegue
+
+### Paso 1: Preparar el Hub
+
+1. Configurar WireGuard con IP `10.10.10.1`
+2. Abrir puerto 3000 en el firewall
+3. Ejecutar:
+   ```bash
+   docker-compose -f docker-compose.coordinator.yml up --build
+   ```
+
+### Paso 2: Preparar cada Máquina Edge
+
+1. Configurar WireGuard conectado al Hub
+2. Asignar IP única (10.10.10.2, 10.10.10.3, etc.)
+3. Verificar conectividad: `ping 10.10.10.1`
+4. Ejecutar:
+   ```bash
+   export COORDINATOR_IP=10.10.10.1
+   export EDGE_ID=edge-node-X  # X = número de máquina
+   docker-compose -f docker-compose.edge.yml up --build
+   ```
+
+### Paso 3: Verificación
+
+En el Hub, revisar logs del coordinator:
+```bash
+docker logs coordinator
+```
+
+Deberías ver heartbeats llegando de los diferentes edges.
+
+## Variables de Entorno
+
+### Coordinator
+- `PORT`: Puerto de escucha (default: 3000)
+- `BIND_ADDRESS`: Interfaz de red (default: 0.0.0.0)
+- `RUST_LOG`: Nivel de logging (default: info)
+
+### Edge
+- `COORDINATOR_IP`: IP del Hub en VPN (requerido)
+- `EDGE_ID`: Identificador único del edge (requerido)
+- `PORT`: Puerto local del edge (default: 4000)
+
+### Sensor
+- `EDGE_URL`: URL del edge local (default: http://localhost:4000/reading)
+- `SENSOR_ID`: Identificador del sensor
+
+## Solución de Problemas
+
+### Los edges no pueden conectar al coordinator
+- Verificar VPN: `ping 10.10.10.1` desde la máquina edge
+- Verificar que el coordinator escuche en 0.0.0.0 (no solo localhost)
+- Revisar firewall del Hub
+
+### Los sensores no pueden conectar al edge
+- Verificar que el edge esté corriendo: `docker ps`
+- Verificar `network_mode: host` en los sensores
+- Probar: `curl http://localhost:4000/reading` desde la máquina
+
+### Heartbeats no llegan
+- Verificar `COORD_HB_URL` apunte a `http://10.10.10.1:3000/heartbeat`
+- Revisar logs del edge: `docker logs edge-processor`
+- Verificar logs del coordinator: `docker logs coordinator`

--- a/docker/docker-compose.coordinator.yml
+++ b/docker/docker-compose.coordinator.yml
@@ -1,0 +1,32 @@
+# Docker Compose para el Nodo Coordinator (Hub)
+# 
+# Este archivo debe ejecutarse SOLO en la máquina designada como Hub (Coordinator)
+# IP esperada en la VPN: 10.10.10.1
+#
+# Uso:
+#   docker-compose -f docker-compose.coordinator.yml up --build
+
+version: '3.8'
+
+services:
+  coordinator:
+    build:
+      context: ../
+      dockerfile: docker/coordinator/Dockerfile
+    container_name: coordinator
+    ports:
+      - "3000:3000"
+    environment:
+      - RUST_LOG=info
+      - PORT=3000
+      # El coordinator escucha en todas las interfaces para recibir conexiones VPN
+      - BIND_ADDRESS=0.0.0.0
+    cap_add:
+      - NET_ADMIN
+    restart: unless-stopped
+    networks:
+      - coordinator-network
+
+networks:
+  coordinator-network:
+    driver: bridge

--- a/docker/docker-compose.edge.yml
+++ b/docker/docker-compose.edge.yml
@@ -1,0 +1,74 @@
+# Docker Compose para Nodos Edge + Sensores
+#
+# Este archivo debe ejecutarse en CADA máquina del equipo (excepto el Hub)
+# Cada máquina ejecuta: 1 Edge + 2+ Sensores
+# Los servicios se comunican localmente; el Edge se conecta al Coordinator vía VPN
+#
+# Variables requeridas (ejemplo para máquina con IP 10.10.10.2):
+#   export COORDINATOR_IP=10.10.10.1
+#   export EDGE_ID=edge-node-2
+#   export EDGE_IP=10.10.10.2
+#
+# Uso:
+#   export COORDINATOR_IP=10.10.10.1
+#   export EDGE_ID=edge-node-2
+#   docker-compose -f docker-compose.edge.yml up --build
+
+version: '3.8'
+
+services:
+  edge:
+    build:
+      context: ../
+      dockerfile: docker/edge/Dockerfile
+    container_name: edge-processor
+    ports:
+      - "4000:4000"
+    environment:
+      - RUST_LOG=info
+      - EDGE_ID=${EDGE_ID:-edge-node-local}
+      - PORT=4000
+      # URL del Coordinator a través de VPN
+      - COORDINATOR_URL=http://${COORDINATOR_IP:-10.10.10.1}:3000/submit_report
+      - COORD_HB_URL=http://${COORDINATOR_IP:-10.10.10.1}:3000/heartbeat
+    cap_add:
+      - NET_ADMIN
+    depends_on:
+      - sensor-1
+      - sensor-2
+    networks:
+      - local-edge-network
+    restart: unless-stopped
+
+  sensor-1:
+    build:
+      context: ../
+      dockerfile: docker/sensor/Dockerfile
+    container_name: iot-sensor-1
+    environment:
+      - RUST_LOG=info
+      - SENSOR_ID=sensor-temp-1
+      # Los sensores envían a su Edge local (misma máquina)
+      - EDGE_URL=http://localhost:4000/reading
+    cap_add:
+      - NET_ADMIN
+    network_mode: host  # Comparte red con el host para localhost
+    restart: unless-stopped
+
+  sensor-2:
+    build:
+      context: ../
+      dockerfile: docker/sensor/Dockerfile
+    container_name: iot-sensor-2
+    environment:
+      - RUST_LOG=info
+      - SENSOR_ID=sensor-temp-2
+      - EDGE_URL=http://localhost:4000/reading
+    cap_add:
+      - NET_ADMIN
+    network_mode: host
+    restart: unless-stopped
+
+networks:
+  local-edge-network:
+    driver: bridge

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,15 @@
+# ⚠️ ARCHIVO LEGADO - SOLO PARA PRUEBAS LOCALES
+#
+# Este docker-compose.yml es útil para desarrollo y pruebas locales
+# donde se ejecutan todos los servicios (sensor, edge, coordinator)
+# en una sola máquina sin VPN.
+#
+# Para el CLUSTER DISTRIBUIDO real, usar:
+#   - docker-compose.coordinator.yml (solo en el Hub)
+#   - docker-compose.edge.yml (en cada máquina del equipo)
+#
+# Ver docs/CLUSTER_ROADMAP.md para más información.
+
 version: '3.8'
 
 services:

--- a/docs/CLUSTER_ROADMAP.md
+++ b/docs/CLUSTER_ROADMAP.md
@@ -1,0 +1,133 @@
+# Roadmap: Evolución a Cluster Distribuido
+
+> Este documento describe la transición desde la **prueba local de concepto** hacia la **arquitectura distribuida real** del sistema IoT/Edge.
+
+## Contexto
+
+La implementación actual funcionó como **prueba de concepto local** (todos los servicios en una máquina). Ahora se procede a la fase de **cluster distribuido** donde cada integrante del equipo ejecuta nodos edge y sensores en sus propias máquinas, comunicándose a través de VPN.
+
+---
+
+## Phase 1: Separación de Arquitectura Docker (Prep)
+
+**Objetivo:** Dividir el monolito Docker en configuraciones independientes para cada rol.
+
+**Cambios:**
+- Crear `docker-compose.coordinator.yml` (solo para el Hub - 10.10.10.1)
+- Crear `docker-compose.edge.yml` (para cada máquina del equipo)
+- Actualizar variables de entorno para IPs VPN en lugar de nombres de servicio Docker
+- Documentar qué equipo ejecuta qué
+
+**Archivos afectados:**
+- `docker/docker-compose.coordinator.yml` (nuevo)
+- `docker/docker-compose.edge.yml` (nuevo)
+- `docker/docker-compose.yml` (deprecado/marcado como local-only)
+
+---
+
+## Phase 2: Corrección de Heartbeats (Arquitectura)
+
+**Objetivo:** Alinear el sistema con la arquitectura donde solo los Edges envían heartbeats.
+
+**Razonamiento:** En el cluster distribuido, el Coordinator necesita monitorear la salud de los Edges remotos (en diferentes máquinas físicas). Los sensores son efímeros y locales a cada máquina, por lo que no necesitan heartbeat directo.
+
+**Cambios:**
+- Remover envío de heartbeats desde `rust/sensor/src/main.rs`
+- Actualizar `rust/common/src/lib.rs` - marcar `role` en Heartbeat como opcional o remover "sensor"
+- Verificar que `rust/coordinator/src/main.rs` solo trackee edges (ignorar heartbeats de sensores si llegan)
+
+**Archivos afectados:**
+- `rust/sensor/src/main.rs`
+- `rust/common/src/lib.rs` (opcional)
+- `docker-compose.edge.yml` (remover COORD_HB_URL del sensor)
+
+---
+
+## Phase 3: Configuración VPN WireGuard (Infraestructura)
+
+**Objetivo:** Actualizar la configuración de VPN para la red 10.10.10.0/24 del cluster real.
+
+**Cambios:**
+- Actualizar `vpn/wg0.conf.template` con red 10.10.10.0/24
+- Documentar asignación de IPs por equipo:
+  - Hub (Coordinator): 10.10.10.1
+  - Miembro 1: 10.10.10.2
+  - Miembro 2: 10.10.10.3
+  - etc.
+- Crear instrucciones de setup VPN por sistema operativo
+
+**Archivos afectados:**
+- `vpn/wg0.conf.template`
+- `vpn/README.md` (nuevo o actualizar existente)
+
+---
+
+## Phase 4: URLs de Comunicación Distribuida (Conectividad)
+
+**Objetivo:** Actualizar todas las URLs de comunicación para usar IPs VPN en lugar de nombres Docker.
+
+**Cambios:**
+- Sensor → Edge: Cambiar de `http://edge:4000` a `http://localhost:4000` (misma máquina)
+- Edge → Coordinator: Cambiar de `http://coordinator:3000` a `http://10.10.10.1:3000`
+- Edge Heartbeat → Coordinator: `http://10.10.10.1:3000/heartbeat`
+
+**Archivos afectados:**
+- `docker/docker-compose.edge.yml` (variables de entorno)
+- `docker/docker-compose.coordinator.yml` (puertos expuestos)
+- Documentación de despliegue
+
+---
+
+## Phase 5: Netem para Red Distribuida (Testing)
+
+**Objetivo:** Adaptar los scripts de netem para afectar el tráfico entre máquinas (VPN) en lugar de tráfico Docker local.
+
+**Cambios:**
+- Crear documentación sobre dónde aplicar netem:
+  - Opción A: Interfaz física (eth0/en0) - afecta todo el tráfico
+  - Opción B: Interfaz WireGuard (wg0) - afecta solo VPN
+- Crear scripts `netem/latencia_vpn.sh` con detección de interfaz
+- Documentar consideraciones: aplicar netem en la máquina que inicia la comunicación
+
+**Archivos afectados:**
+- `netem/README.md` (actualizar)
+- `netem/latencia_vpn.sh` (nuevo)
+
+---
+
+## Phase 6: Scripts de Despliegue y Documentación (Ops)
+
+**Objetivo:** Facilitar el despliegue distribuido con scripts y guías claras.
+
+**Cambios:**
+- Crear `scripts/deploy-coordinator.sh` (para el Hub)
+- Crear `scripts/deploy-edge.sh` (para cada miembro)
+- Actualizar README principal con arquitectura distribuida
+- Crear `docs/DEPLOYMENT_GUIDE.md` con pasos por rol
+
+**Archivos afectados:**
+- `scripts/` (nuevo directorio)
+- `README.md`
+- `docs/DEPLOYMENT_GUIDE.md` (nuevo)
+
+---
+
+## Checklist de Verificación del Cluster
+
+- [ ] VPN levantada entre todas las máquinas (`ping 10.10.10.1` funciona desde edges)
+- [ ] Coordinator responde en 10.10.10.1:3000
+- [ ] Cada Edge envía heartbeats y son recibidos
+- [ ] Edges envían reportes de anomalías al Coordinator
+- [ ] Sensores locales envían datos a su Edge local
+- [ ] Netem aplicado en interfaz correcta simula latencia entre máquinas
+- [ ] Falla de un Edge es detectada por Coordinator en < 10 segundos
+
+---
+
+## Notas para el Equipo
+
+1. **Quién es el Hub:** Designar una máquina como Hub (Coordinator). Idealmente la más estable.
+2. **WireGuard:** Cada miembro necesita su propia configuración de peer en el Hub.
+3. **Firewall:** Asegurar que el puerto 51820/UDP esté abierto en el Hub.
+4. **Docker:** Todos necesitan Docker y Docker Compose instalados.
+5. **Red local:** Los contenedores en la misma máquina se comunican por localhost/bridge, no por VPN.


### PR DESCRIPTION
Este commit evoluciona el sistema desde prueba local hacia cluster distribuido:

- Agregar docker-compose.coordinator.yml para el Hub (Rogelio) (10.10.10.1)
- Agregar docker-compose.edge.yml para nodos edge de cada máquina
- Marcar docker-compose.yml como legacy (solo pruebas locales)
- Agregar documentación de arquitectura distribuida
- Crear roadmap del cluster en docs/CLUSTER_ROADMAP.md

La prueba de concepto local fue exitosa. Ahora se prepara la infraestructura para el despliegue distribuido real con VPN.