### PR TITLE
feat(cluster): Scripts netem para red distribuida

### DIFF
--- a/netem/README.md
+++ b/netem/README.md
@@ -2,35 +2,124 @@
 
 Esta carpeta contiene los scripts necesarios para simular condiciones adversas de red en el pipeline IoT/Edge.
 
-## Escenarios Disponibles
+## ⚠️ Diferencia: Prueba Local vs Cluster Distribuido
 
-1.  `baseline.sh`: Restaura la red a su estado normal (limpia todas las reglas).
-2.  `apply_latency.sh`: Inyecta una latencia fija de **140ms**. Útil para pruebas de estrés.
-3.  `latencia_iot.sh`: Simula una red IoT real con **80ms de retraso y 20ms de jitter**.
+### Prueba Local (Legacy)
+- Scripts aplican netem **dentro de contenedores Docker**
+- Solo afecta tráfico entre contenedores en la misma máquina
+- Usar scripts originales: `baseline.sh`, `apply_latency.sh`, `latencia_iot.sh`
 
-## Validación con iperf3 (OBLIGATORIO)
+### Cluster Distribuido (Actual)
+- Scripts aplican netem en la **interfaz de red del host**
+- Afecta tráfico entre máquinas a través de la VPN
+- Usar scripts específicos: `latencia_vpn.sh`, `baseline_vpn.sh`
 
-Para evidenciar que los scripts están funcionando, se debe utilizar la herramienta `iperf3` entre dos contenedores.
+## Escenarios Disponibles - Cluster Distribuido
 
-### Paso 1: Preparar el Servidor
-En el contenedor del **Coordinador**, inicia el servidor de iperf3:
+Para el despliegue real con VPN, usar estos scripts en las máquinas físicas:
+
+### 1. `latencia_vpn.sh` - Simular Red IoT Real
+Aplica **80ms de latencia + 20ms de jitter** en la interfaz de red.
+
 ```bash
-docker exec -it coordinator iperf3 -s
+# Detectar interfaz automáticamente
+sudo ./netem/latencia_vpn.sh
+
+# O especificar interfaz manualmente
+sudo ./netem/latencia_vpn.sh eth0
 ```
 
-### Paso 2: Aplicar Escenario
-En el contenedor del **Edge**, aplica uno de los scripts:
+### 2. `baseline_vpn.sh` - Restaurar Red Normal
+Limpia todas las reglas de netem de la interfaz:
+
 ```bash
-docker exec -it edge-processor ./netem/latencia_iot.sh
+sudo ./netem/baseline_vpn.sh
+# o con interfaz específica:
+sudo ./netem/baseline_vpn.sh eth0
 ```
 
-### Paso 3: Ejecutar el Cliente y Capturar Evidencia
-Desde el contenedor del **Edge**, lanza la prueba hacia el coordinador:
+## ¿Dónde Aplicar netem en el Cluster?
+
+### Opción A: Interfaz Física (eth0/en0)
+**Afecta**: Todo el tráfico de red de la máquina.
+
 ```bash
-docker exec -it edge-processor iperf3 -c coordinator
+# Linux
+sudo tc qdisc add dev eth0 root netem delay 80ms 20ms
+
+# macOS (usa pfctl, diferente sintaxis)
 ```
 
-### Qué observar en la captura:
-*   **Sin script:** La latencia debe ser mínima (< 1ms en red local de Docker).
-*   **Con latencia_iot.sh:** El reporte de iperf3 mostrará tiempos de transferencia consistentes con el retraso de 80ms aplicado.
-*   **Jitter:** Al usar `ping coordinator`, verás que los tiempos varían entre ráfagas debido al jitter de 20ms.
+**Pros:**
+- Afecta todo el tráfico incluyendo VPN
+- Simula condiciones reales de red del host
+
+**Contras:**
+- Afecta otras aplicaciones
+- Puede afectar SSH si se aplica en la máquina remota
+
+### Opción B: Interfaz WireGuard (wg0) ⭐ Recomendado
+**Afecta**: Solo tráfico que pasa por la VPN.
+
+```bash
+sudo tc qdisc add dev wg0 root netem delay 80ms 20ms
+```
+
+**Pros:**
+- Solo afecta tráfico del cluster
+- No interfiere con otras aplicaciones
+- Más realista para el proyecto
+
+**Contras:**
+- NetEm debe aplicarse después de que wg0 esté activa
+- Algunos sistemas aplican reglas en orden diferente
+
+### ⚠️ Consideración Importante (del Documento E)
+
+Según el post-mortem del proyecto, aplicar netem sobre `wg0` a veces **no afecta** el tráfico inter-contenedor porque los paquetes ya se desencapsularon antes de llegar a netem.
+
+**Recomendación del proyecto:**
+1. Primero intentar con interfaz física (`eth0`/`en0`)
+2. Si no funciona, intentar con `wg0`
+3. Documentar qué interfaz funcionó para la entrega
+
+## Validación con iperf3 (Cluster Distribuido)
+
+Para evidenciar que netem está funcionando en el cluster:
+
+### Paso 1: Preparar el Servidor (Hub)
+En la máquina del **Coordinator (10.10.10.1)**, iniciar iperf3:
+
+```bash
+iperf3 -s
+```
+
+### Paso 2: Aplicar Escenario (Edge)
+En una máquina **Edge** (ej: 10.10.10.2), aplicar netem:
+
+```bash
+# Verificar que la VPN funciona
+ping 10.10.10.1
+
+# Aplicar latencia
+sudo ./netem/latencia_vpn.sh
+```
+
+### Paso 3: Ejecutar Prueba
+Desde la misma máquina Edge, lanzar iperf3 hacia el Coordinator:
+
+```bash
+iperf3 -c 10.10.10.1
+```
+
+### Qué observar:
+- **Sin netem**: Latencia mínima (< 5ms en red local de VPN)
+- **Con netem**: Latencia ~80ms con variación (jitter)
+
+### Paso 4: Verificar con ping
+
+```bash
+ping 10.10.10.1
+```
+
+Deberías ver tiempos de respuesta alrededor de 80ms con ±20ms de variación.

--- a/netem/baseline_vpn.sh
+++ b/netem/baseline_vpn.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Restaura la interfaz de red a su estado normal (sin netem)
+# Uso: sudo ./baseline_vpn.sh [interfaz]
+# Ejemplo: sudo ./baseline_vpn.sh eth0
+
+set -e
+
+# Colores para output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Detectar interfaz si no se proporciona
+if [ -z "$1" ]; then
+    echo -e "${YELLOW}No se especificó interfaz. Detectando automáticamente...${NC}"
+
+    if command -v ip &> /dev/null; then
+        INTERFACE=$(ip route | grep default | head -n1 | awk '{print $5}')
+    elif command -v route &> /dev/null; then
+        INTERFACE=$(route -n get default 2>/dev/null | grep interface | awk '{print $2}')
+        if [ -z "$INTERFACE" ]; then
+            INTERFACE=$(netstat -rn | grep default | head -n1 | awk '{print $6}')
+        fi
+    fi
+
+    if [ -z "$INTERFACE" ]; then
+        echo -e "${RED}Error: No se pudo detectar interfaz automáticamente.${NC}"
+        echo "Uso: sudo $0 <interfaz>"
+        exit 1
+    fi
+
+    echo -e "${GREEN}Interfaz detectada: $INTERFACE${NC}"
+else
+    INTERFACE="$1"
+    echo -e "${GREEN}Usando interfaz especificada: $INTERFACE${NC}"
+fi
+
+# Verificar permisos de root
+if [ "$EUID" -ne 0 ]; then
+    echo -e "${RED}Error: Se requieren permisos de root (sudo).${NC}"
+    exit 1
+fi
+
+# Verificar que tc esté disponible
+if ! command -v tc &> /dev/null; then
+    echo -e "${RED}Advertencia: 'tc' no está instalado.${NC}"
+    exit 1
+fi
+
+echo -e "${YELLOW}Limpiando reglas de netem de ${INTERFACE}...${NC}"
+
+# Intentar eliminar reglas de netem
+if tc qdisc del dev "$INTERFACE" root 2>/dev/null; then
+    echo -e "${GREEN}✓ Reglas de netem removidas exitosamente${NC}"
+else
+    echo -e "${YELLOW}No había reglas de netem activas en ${INTERFACE}${NC}"
+fi
+
+# Mostrar estado actual
+echo ""
+echo "Estado actual de tc en ${INTERFACE}:"
+tc qdisc show dev "$INTERFACE" || echo "  (no hay reglas configuradas)"
+
+echo ""
+echo -e "${GREEN}La red ha sido restaurada a su estado normal.${NC}"

--- a/netem/latencia_vpn.sh
+++ b/netem/latencia_vpn.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Simula red IoT real con latencia y jitter en la interfaz de red del host
+# Uso: sudo ./latencia_vpn.sh [interfaz]
+# Ejemplo: sudo ./latencia_vpn.sh eth0
+
+set -e
+
+# Colores para output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Configuración de latencia
+LATENCY="80ms"
+JITTER="20ms"
+DISTRIBUTION="normal"
+
+# Detectar interfaz si no se proporciona
+if [ -z "$1" ]; then
+    echo -e "${YELLOW}No se especificó interfaz. Detectando automáticamente...${NC}"
+
+    # Intentar detectar interfaz principal (conectada a internet)
+    if command -v ip &> /dev/null; then
+        # Linux con iproute2
+        INTERFACE=$(ip route | grep default | head -n1 | awk '{print $5}')
+    elif command -v route &> /dev/null; then
+        # macOS o Linux antiguo
+        INTERFACE=$(route -n get default 2>/dev/null | grep interface | awk '{print $2}')
+        if [ -z "$INTERFACE" ]; then
+            INTERFACE=$(netstat -rn | grep default | head -n1 | awk '{print $6}')
+        fi
+    fi
+
+    # Si tenemos wg0 activa, sugerirla
+    if ip link show wg0 &> /dev/null; then
+        echo -e "${YELLOW}WireGuard detectado (wg0). ¿Deseas usar wg0? (s/n)${NC}"
+        read -r response
+        if [ "$response" = "s" ] || [ "$response" = "S" ]; then
+            INTERFACE="wg0"
+        fi
+    fi
+
+    if [ -z "$INTERFACE" ]; then
+        echo -e "${RED}Error: No se pudo detectar interfaz automáticamente.${NC}"
+        echo "Uso: sudo $0 <interfaz>"
+        echo "Ejemplo: sudo $0 eth0"
+        exit 1
+    fi
+
+    echo -e "${GREEN}Interfaz detectada: $INTERFACE${NC}"
+else
+    INTERFACE="$1"
+    echo -e "${GREEN}Usando interfaz especificada: $INTERFACE${NC}"
+fi
+
+# Verificar que tc esté disponible
+if ! command -v tc &> /dev/null; then
+    echo -e "${RED}Error: 'tc' (traffic control) no está instalado.${NC}"
+    echo "Instalar en Ubuntu/Debian: sudo apt-get install iproute2"
+    echo "Instalar en macOS: tc viene con el sistema (a veces)"
+    exit 1
+fi
+
+# Verificar permisos de root
+if [ "$EUID" -ne 0 ]; then
+    echo -e "${RED}Error: Se requieren permisos de root (sudo).${NC}"
+    exit 1
+fi
+
+# Verificar que la interfaz existe
+if ! ip link show "$INTERFACE" &> /dev/null; then
+    echo -e "${RED}Error: La interfaz '$INTERFACE' no existe.${NC}"
+    echo "Interfaces disponibles:"
+    ip link show | grep -E "^[0-9]+:" | awk -F: '{print $2}' | sed 's/^ //'
+    exit 1
+fi
+
+echo -e "${YELLOW}Aplicando netem: ${LATENCY} delay ±${JITTER} en ${INTERFACE}${NC}"
+
+# Limpiar reglas existentes (si las hay)
+tc qdisc del dev "$INTERFACE" root 2>/dev/null || true
+
+# Aplicar netem
+if tc qdisc add dev "$INTERFACE" root netem delay "$LATENCY" "$JITTER" distribution "$DISTRIBUTION"; then
+    echo -e "${GREEN}✓ Latencia IoT aplicada exitosamente${NC}"
+    echo -e "  Interfaz: $INTERFACE"
+    echo -e "  Latencia: $LATENCY"
+    echo -e "  Jitter: ±$JITTER"
+    echo ""
+    echo -e "${YELLOW}Para verificar:${NC}"
+    echo "  ping 10.10.10.1  # (desde edge hacia hub)"
+    echo ""
+    echo -e "${YELLOW}Para remover:${NC}"
+    echo "  sudo ./baseline_vpn.sh $INTERFACE"
+else
+    echo -e "${RED}✗ Error al aplicar netem${NC}"
+    exit 1
+fi
+
+# Mostrar reglas actuales
+echo ""
+echo "Reglas actuales de tc:"
+tc qdisc show dev "$INTERFACE"


### PR DESCRIPTION
Actualizar netem para aplicarse en interfaces de host, no contenedores:

- Actualizar netem/README.md con diferencias local vs cluster
- Crear latencia_vpn.sh: aplica 80ms+20ms jitter en interfaz física/VPN
- Crear baseline_vpn.sh: limpia reglas netem de interfaz
- Documentar opciones: interfaz física (eth0) vs WireGuard (wg0)
- Incluir recomendación del Documento E sobre wg0

Los scripts detectan interfaz automáticamente o permiten especificarla. Listos para aplicar en máquinas del cluster distribuido.